### PR TITLE
Vertikoff/duration

### DIFF
--- a/heart_rate_monitor.py
+++ b/heart_rate_monitor.py
@@ -9,6 +9,7 @@ class HeartRateMonitor:
         self.beats = None
         self.import_data()
         self.set_voltage_extremes()
+        self.set_duration()
 
     def import_data(self):
         from import_csv import ImportCSV
@@ -19,8 +20,23 @@ class HeartRateMonitor:
         min_voltage = None
         max_voltage = None
         for reading in self.list_data:
-            if(max_voltage is None or reading[1] > max_voltage):
-                max_voltage = reading[1]
-            if(min_voltage is None or reading[1] < min_voltage):
-                min_voltage = reading[1]
+            voltage = float(reading[1])
+            if(max_voltage is None or voltage > max_voltage):
+                max_voltage = voltage
+            if(min_voltage is None or voltage < min_voltage):
+                min_voltage = voltage
         self.voltage_extremes = (min_voltage, max_voltage)
+
+    def set_duration(self):
+        # CRV init the max and min timestamp
+        min_ts = None
+        max_ts = None
+        for reading in self.list_data:
+            ts = float(reading[0])
+            if(max_ts is None or ts > max_ts):
+                max_ts = ts
+            if(min_ts is None or ts < min_ts):
+                min_ts = ts
+        # CRV - calculating the diff here just incase there is an offset error
+        # (earliest ts in data set NOT 0)
+        self.duration = max_ts - min_ts

--- a/test_heart_rate_monitor.py
+++ b/test_heart_rate_monitor.py
@@ -11,7 +11,16 @@ def test_voltage_extremes():
     import pytest
     from heart_rate_monitor import HeartRateMonitor
     a = HeartRateMonitor('test_data/test_data1.csv').voltage_extremes
-    assert a == ('-0.005', '1.05')
+    assert a == (-0.68, 1.05)
 
     with pytest.raises(ImportError):
         HeartRateMonitor('fake_dir/not_real.csv').voltage_extremes
+
+def test_duration():
+    import pytest
+    from heart_rate_monitor import HeartRateMonitor
+    a = HeartRateMonitor('test_data/test_data1.csv').duration
+    assert a == 27.775
+
+    with pytest.raises(ImportError):
+        HeartRateMonitor('fake_dir/not_real.csv').duration

--- a/test_heart_rate_monitor.py
+++ b/test_heart_rate_monitor.py
@@ -16,6 +16,7 @@ def test_voltage_extremes():
     with pytest.raises(ImportError):
         HeartRateMonitor('fake_dir/not_real.csv').voltage_extremes
 
+
 def test_duration():
     import pytest
     from heart_rate_monitor import HeartRateMonitor


### PR DESCRIPTION
Adds a set_duration method to the HeartRateMonitor class. 

This method is called during the initialization of a new instance of the HeartRateMonitor class. The duration value is a float that can be accessed anytime in the `self.duration` property of any instance of the `HeartRateMonitor` class.