### PR TITLE
vertikoff/HotFixVoltageMaxAndMin

### DIFF
--- a/heart_rate_monitor.py
+++ b/heart_rate_monitor.py
@@ -9,7 +9,7 @@ class HeartRateMonitor:
         self.num_beats = None
         self.beats = None
         self.import_data()
-        # self.set_voltage_extremes()
+        self.set_voltage_extremes()
         # self.set_duration()
 
     def import_data(self):
@@ -20,14 +20,8 @@ class HeartRateMonitor:
 
     def set_voltage_extremes(self):
         # CRV init max and min voltage tuple
-        min_voltage = None
-        max_voltage = None
-        for reading in self.list_data:
-            voltage = float(reading[1])
-            if(max_voltage is None or voltage > max_voltage):
-                max_voltage = voltage
-            if(min_voltage is None or voltage < min_voltage):
-                min_voltage = voltage
+        min_voltage = min(self.voltages)
+        max_voltage = max(self.voltages)
         self.voltage_extremes = (min_voltage, max_voltage)
 
     def set_duration(self):

--- a/test_heart_rate_monitor.py
+++ b/test_heart_rate_monitor.py
@@ -8,14 +8,13 @@ def test_import_csv():
 
 
 def test_voltage_extremes():
-    pass
-    # import pytest
-    # from heart_rate_monitor import HeartRateMonitor
-    # a = HeartRateMonitor('test_data/test_data1.csv').voltage_extremes
-    # assert a == (-0.68, 1.05)
-    #
-    # with pytest.raises(ImportError):
-    #     HeartRateMonitor('fake_dir/not_real.csv').voltage_extremes
+    import pytest
+    from heart_rate_monitor import HeartRateMonitor
+    a = HeartRateMonitor('test_data/test_data1.csv').voltage_extremes
+    assert a == (-0.68, 1.05)
+
+    with pytest.raises(ImportError):
+        HeartRateMonitor('fake_dir/not_real.csv').voltage_extremes
 
 
 def test_duration():


### PR DESCRIPTION
Updates the `set_voltage_extremes` method to use the build in python list methods `min()` and `max()` rather than iterating over the entire data set. 