### PR TITLE
vertikoff/HotFixDuration

### DIFF
--- a/heart_rate_monitor.py
+++ b/heart_rate_monitor.py
@@ -10,7 +10,7 @@ class HeartRateMonitor:
         self.beats = None
         self.import_data()
         self.set_voltage_extremes()
-        # self.set_duration()
+        self.set_duration()
 
     def import_data(self):
         from import_csv import ImportCSV
@@ -26,14 +26,8 @@ class HeartRateMonitor:
 
     def set_duration(self):
         # CRV init the max and min timestamp
-        min_ts = None
-        max_ts = None
-        for reading in self.list_data:
-            ts = float(reading[0])
-            if(max_ts is None or ts > max_ts):
-                max_ts = ts
-            if(min_ts is None or ts < min_ts):
-                min_ts = ts
+        min_ts = min(self.timestamps)
+        max_ts = max(self.timestamps)
         # CRV - calculating the diff here just incase there is an offset error
         # (earliest ts in data set NOT 0)
         self.duration = max_ts - min_ts

--- a/test_heart_rate_monitor.py
+++ b/test_heart_rate_monitor.py
@@ -18,11 +18,10 @@ def test_voltage_extremes():
 
 
 def test_duration():
-    pass
-    # import pytest
-    # from heart_rate_monitor import HeartRateMonitor
-    # a = HeartRateMonitor('test_data/test_data1.csv').duration
-    # assert a == 27.775
-    #
-    # with pytest.raises(ImportError):
-    #     HeartRateMonitor('fake_dir/not_real.csv').duration
+    import pytest
+    from heart_rate_monitor import HeartRateMonitor
+    a = HeartRateMonitor('test_data/test_data1.csv').duration
+    assert a == 27.775
+
+    with pytest.raises(ImportError):
+        HeartRateMonitor('fake_dir/not_real.csv').duration


### PR DESCRIPTION
Again, rather than iterating over all the data to get the duration, we can use the native `min()` and `max()` methods. 