### PR TITLE
Vertikoff/MeanHrBpm

### DIFF
--- a/heart_rate_monitor.py
+++ b/heart_rate_monitor.py
@@ -13,6 +13,7 @@ class HeartRateMonitor:
         self.set_voltage_extremes()
         self.set_duration()
         self.find_beats()
+        self.calc_mean_hr_bpm()
 
     def import_data(self):
         from import_csv import ImportCSV
@@ -50,11 +51,18 @@ class HeartRateMonitor:
         self.num_beats = len(self.beats)
         # CRV convert list to numpy array
         self.beats = np.array(self.beats)
-    #
-    # def mean_hr_bpm(start_ts = None, end_ts = None):
-    #     if(start_ts is None):
-    #         start_ts = self.timestamps[0]
-    #
+
+    def calc_mean_hr_bpm(self, start_ts=None, end_ts=None):
+        if(start_ts is None or not self.is_valid_ts(start_ts)):
+            start_ts = self.timestamps[0]
+        if(end_ts is None or not self.is_valid_ts(end_ts)):
+            end_ts = self.timestamps[-1]
+        num_beats_in_range = 0
+        for beat_ts in self.beats:
+            if(start_ts <= beat_ts <= end_ts):
+                num_beats_in_range += 1
+        percentage_of_min = self.calc_percentage_of_min(start_ts, end_ts)
+        self.mean_hr_bpm = self.calc_bpm(num_beats_in_range, percentage_of_min)
 
     def is_valid_ts(self, timestamp):
         min_ts = self.timestamps[0]
@@ -63,3 +71,17 @@ class HeartRateMonitor:
             return(True)
         else:
             return(False)
+
+    def calc_percentage_of_min(self, start_ts, end_ts):
+        if((isinstance(start_ts, int) or isinstance(start_ts, float)) and
+           (isinstance(end_ts, int) or isinstance(end_ts, float))):
+            return((end_ts - start_ts)/60)
+        else:
+            raise TypeError('start_ts and end_ts must be floats or ints')
+
+    def calc_bpm(self, beats, percentage_of_min):
+        if((isinstance(beats, int) or isinstance(beats, float)) and
+           (isinstance(percentage_of_min, int) or isinstance(percentage_of_min, float))):
+            return(beats/percentage_of_min)
+        else:
+            raise TypeError('beats and percentage_of_min must be floats or ints')

--- a/heart_rate_monitor.py
+++ b/heart_rate_monitor.py
@@ -77,11 +77,12 @@ class HeartRateMonitor:
            (isinstance(end_ts, int) or isinstance(end_ts, float))):
             return((end_ts - start_ts)/60)
         else:
-            raise TypeError('start_ts and end_ts must be floats or ints')
+            raise TypeError('start_ts and end_ts must be float or int')
 
     def calc_bpm(self, beats, percentage_of_min):
         if((isinstance(beats, int) or isinstance(beats, float)) and
-           (isinstance(percentage_of_min, int) or isinstance(percentage_of_min, float))):
+           (isinstance(percentage_of_min, int) or
+            isinstance(percentage_of_min, float))):
             return(beats/percentage_of_min)
         else:
-            raise TypeError('beats and percentage_of_min must be floats or ints')
+            raise TypeError('beats and percentage_of_min must be float or int')

--- a/heart_rate_monitor.py
+++ b/heart_rate_monitor.py
@@ -50,3 +50,16 @@ class HeartRateMonitor:
         self.num_beats = len(self.beats)
         # CRV convert list to numpy array
         self.beats = np.array(self.beats)
+    #
+    # def mean_hr_bpm(start_ts = None, end_ts = None):
+    #     if(start_ts is None):
+    #         start_ts = self.timestamps[0]
+    #
+
+    def is_valid_ts(self, timestamp):
+        min_ts = self.timestamps[0]
+        max_ts = self.timestamps[-1]
+        if(min_ts <= timestamp <= max_ts):
+            return(True)
+        else:
+            return(False)

--- a/heart_rate_monitor.py
+++ b/heart_rate_monitor.py
@@ -82,7 +82,7 @@ class HeartRateMonitor:
     def calc_bpm(self, beats, percentage_of_min):
         if((isinstance(beats, int) or isinstance(beats, float)) and
            (isinstance(percentage_of_min, int) or
-            isinstance(percentage_of_min, float))):
+           isinstance(percentage_of_min, float))):
             return(beats/percentage_of_min)
         else:
             raise TypeError('beats and percentage_of_min must be float or int')

--- a/test_heart_rate_monitor.py
+++ b/test_heart_rate_monitor.py
@@ -35,3 +35,15 @@ def test_find_beats():
 
     with pytest.raises(ImportError):
         HeartRateMonitor('fake_dir/not_real.csv').num_beats
+
+
+def test_is_valid_ts():
+    import pytest
+    from heart_rate_monitor import HeartRateMonitor
+    a = HeartRateMonitor('test_data/test_data1.csv')
+    b = a.is_valid_ts(15.5)
+    c = a.is_valid_ts(150000.6)
+    d = a.is_valid_ts(0)
+    assert b == True
+    assert c == False
+    assert d == True

--- a/test_heart_rate_monitor.py
+++ b/test_heart_rate_monitor.py
@@ -47,3 +47,43 @@ def test_is_valid_ts():
     assert b == True
     assert c == False
     assert d == True
+
+
+def test_calc_mean_hr_bpm():
+    import pytest
+    from heart_rate_monitor import HeartRateMonitor
+    a = HeartRateMonitor('test_data/test_data1.csv').mean_hr_bpm
+    assert a == 75.60756075607561
+
+    with pytest.raises(ImportError):
+        HeartRateMonitor('fake_dir/not_real.csv').num_beats
+
+
+def test_calc_percentage_of_min():
+    import pytest
+    from heart_rate_monitor import HeartRateMonitor
+    a = HeartRateMonitor('test_data/test_data1.csv')
+    b = a.calc_percentage_of_min(0, 60)
+    c = a.calc_percentage_of_min(15, 30)
+    d = a.calc_percentage_of_min(15, 90)
+    assert b == 1.0
+    assert c == 0.25
+    assert d == 1.25
+
+    with pytest.raises(TypeError):
+        a.calc_percentage_of_min('start', 45)
+
+
+def test_calc_bpm():
+    import pytest
+    from heart_rate_monitor import HeartRateMonitor
+    a = HeartRateMonitor('test_data/test_data1.csv')
+    b = a.calc_bpm(10, 1.0)
+    c = a.calc_bpm(15, 0.5)
+    d = a.calc_bpm(90, 1.5)
+    assert b == 10
+    assert c == 30
+    assert d == 60
+
+    with pytest.raises(TypeError):
+        a.calc_bpm('start', 45)

--- a/test_heart_rate_monitor.py
+++ b/test_heart_rate_monitor.py
@@ -44,9 +44,9 @@ def test_is_valid_ts():
     b = a.is_valid_ts(15.5)
     c = a.is_valid_ts(150000.6)
     d = a.is_valid_ts(0)
-    assert b == True
-    assert c == False
-    assert d == True
+    assert b is True
+    assert c is False
+    assert d is True
 
 
 def test_calc_mean_hr_bpm():


### PR DESCRIPTION
This branch adds functionality to calculate the mean heart rate bpm over any valid time range. 

When instances of the `HeartRateMonitor` class are created, the class automatically calculates the mean BPM over the entire data set. However, users can always update the mean BPM over any valid time range they would like. This can be achieved by calling the `calc_mean_hr_bpm(start_ts, end_ts)` method. `start_ts` and `end_ts` need to be within the range of the uploaded csv data. If they aren't, `start_ts` will be defaulted to the first timestamp in the data set. Similarly, if `end_ts` doesn't exist in the data set, it will be defaulted to the last timestamp in the data set. 